### PR TITLE
fix:  Support String escaping for non-token text

### DIFF
--- a/src/lib/mapFormat.ts
+++ b/src/lib/mapFormat.ts
@@ -34,7 +34,9 @@ const momentToLuxonMap: {[key: string]: string} = {
   "X": "X",
   "x": "x",
   "[": "'",
-  "]": "'"
+  "]": "'",
+  "\\[": "'\\'",
+  "\\]": "'",
 };
 
 export const mapFormat = (momentFormat: string) => {

--- a/src/lib/mapFormat.ts
+++ b/src/lib/mapFormat.ts
@@ -32,7 +32,9 @@ const momentToLuxonMap: {[key: string]: string} = {
   "Z": "ZZ",
   "ZZ": "ZZ",
   "X": "X",
-  "x": "x"
+  "x": "x",
+  "[": "'",
+  "]": "'"
 };
 
 export const mapFormat = (momentFormat: string) => {


### PR DESCRIPTION
### Adding support for non-token text.

#### Moment format:
`moment().format("[Today is] dddd");     // => "Today is Sunday"`

#### Luxon format:
`DateTime.now().toFormat("HH 'hours and' mm 'minutes'"); //=> '20 hours and 55 minutes'`

### Testing

#### Test case 1
Moment token to convert:
YYYY-[W]ww

Converted format to Luxon:
yyyy-'W'WW

Converted date:
2024-W04

#### Test case 2
Moment token to convert:
YYYY-[this istest with spaces]ww

Converted format to Luxon:
yyyy-'this istest With spaces'WW

Converted date:
2024-this istest With spaces04
